### PR TITLE
Add next and back buttons

### DIFF
--- a/Assets/Scripts/GamePreparation/CardCollection.cs
+++ b/Assets/Scripts/GamePreparation/CardCollection.cs
@@ -30,6 +30,7 @@ public class CardCollection : MonoBehaviour
             GameObject cardObj = cardsInScene[cards[i].guid];
 
             cardObj.GetComponent<SimpleCard>().UpdateClickAction(preparationMain.moveCardToPlayerSelection);
+            cardObj.transform.parent = transform;
             cardObj.transform.localPosition = xOffset * currentRowSize * Vector3.right;
             cardObj.transform.localPosition += yOffset * rowNumber * Vector3.down;
             currentRowSize++;

--- a/Assets/Scripts/GamePreparation/CardCollection.cs
+++ b/Assets/Scripts/GamePreparation/CardCollection.cs
@@ -26,10 +26,10 @@ public class CardCollection : MonoBehaviour
             }
 
             if (!cardsInScene.ContainsKey(cards[i].guid))
-                cardsInScene[cards[i].guid] = cardCreator.createCard(cards[i], transform, preparationMain.moveCardToPlayerSelection);
+                cardsInScene[cards[i].guid] = cardCreator.createCard(cards[i], transform, preparationMain.MoveCardToPlayerSelection);
             GameObject cardObj = cardsInScene[cards[i].guid];
 
-            cardObj.GetComponent<SimpleCard>().UpdateClickAction(preparationMain.moveCardToPlayerSelection);
+            cardObj.GetComponent<SimpleCard>().UpdateClickAction(preparationMain.MoveCardToPlayerSelection);
             cardObj.transform.parent = transform;
             cardObj.transform.localPosition = xOffset * currentRowSize * Vector3.right;
             cardObj.transform.localPosition += yOffset * rowNumber * Vector3.down;

--- a/Assets/Scripts/GamePreparation/PlayerSelection.cs
+++ b/Assets/Scripts/GamePreparation/PlayerSelection.cs
@@ -15,10 +15,10 @@ public class PlayerSelection : MonoBehaviour
         for (int i = 0; i < cards.Count; i++)
         {
             if (!cardsInScene.ContainsKey(cards[i].guid))
-                cardsInScene[cards[i].guid] = cardCreator.createCard(cards[i], transform, preparationMain.moveCardToCollection);
+                cardsInScene[cards[i].guid] = cardCreator.createCard(cards[i], transform, preparationMain.MoveCardToCollection);
             GameObject cardObj = cardsInScene[cards[i].guid];
 
-            cardObj.GetComponent<SimpleCard>().UpdateClickAction(preparationMain.moveCardToCollection);
+            cardObj.GetComponent<SimpleCard>().UpdateClickAction(preparationMain.MoveCardToCollection);
             cardObj.transform.parent = transform;
             cardObj.transform.localPosition = yOffset * i * Vector3.down;
         }

--- a/Assets/Scripts/GamePreparation/PlayerSelection.cs
+++ b/Assets/Scripts/GamePreparation/PlayerSelection.cs
@@ -19,6 +19,7 @@ public class PlayerSelection : MonoBehaviour
             GameObject cardObj = cardsInScene[cards[i].guid];
 
             cardObj.GetComponent<SimpleCard>().UpdateClickAction(preparationMain.moveCardToCollection);
+            cardObj.transform.parent = transform;
             cardObj.transform.localPosition = yOffset * i * Vector3.down;
         }
     }

--- a/Assets/Scripts/GamePreparation/PreparationLogicHolder.cs
+++ b/Assets/Scripts/GamePreparation/PreparationLogicHolder.cs
@@ -20,15 +20,15 @@ public class PreparationLogicHolder : MonoBehaviour
     public PreparationLogic player2Preparation;
     public PlayerID currentPlayer;
 
+    bool IsPlayer1Active() { return currentPlayer == PlayerID.Player1; }
+
     public PreparationLogic GetCurrentPreparationLogic()
     {
-        if (currentPlayer == PlayerID.Player1)
-            return player1Preparation;
-        return player2Preparation;
+        return IsPlayer1Active() ? player1Preparation : player2Preparation;
     }
     public void SetCurrentPreparationLogic(PreparationLogic logic)
     {
-        if (currentPlayer == PlayerID.Player1)
+        if (IsPlayer1Active())
             player1Preparation = logic;
         else
             player2Preparation = logic;

--- a/Assets/Scripts/GamePreparation/PreparationLogicHolder.cs
+++ b/Assets/Scripts/GamePreparation/PreparationLogicHolder.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using BoardGame.Cards;
+using BoardGame.Preparation;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+public class PreparationLogicHolder : MonoBehaviour
+{
+
+    public enum PlayerID
+    {
+        Player1,
+        Player2
+    };
+
+    public PreparationLogic player1Preparation;
+    public PreparationLogic player2Preparation;
+    public PlayerID currentPlayer;
+
+    public PreparationLogic GetCurrentPreparationLogic()
+    {
+        if (currentPlayer == PlayerID.Player1)
+            return player1Preparation;
+        return player2Preparation;
+    }
+    public void SetCurrentPreparationLogic(PreparationLogic logic)
+    {
+        if (currentPlayer == PlayerID.Player1)
+            player1Preparation = logic;
+        else
+            player2Preparation = logic;
+    }
+
+}

--- a/Assets/Scripts/GamePreparation/PreparationLogicHolder.cs.meta
+++ b/Assets/Scripts/GamePreparation/PreparationLogicHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1985685e1b53949ee8f31e97e098fe34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GamePreparation/PreparationMain.cs
+++ b/Assets/Scripts/GamePreparation/PreparationMain.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BoardGame.Cards;
 using BoardGame.Preparation;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
@@ -26,7 +27,7 @@ public class PreparationMain : MonoBehaviour
 
     // Start is called before the first frame update
 
-    PreparationLogicHolder GetOrCreateHolder()
+    PreparationLogicHolder GetHolder()
     {
         GameObject obj = GameObject.Find("/PreparationLogicHolder");
         PreparationLogicHolder holder;
@@ -53,45 +54,53 @@ public class PreparationMain : MonoBehaviour
     {
         Debug.Log("start preparation main");
 
-        preparationLogicHolder = GetOrCreateHolder();
+        preparationLogicHolder = GetHolder();
         DontDestroyOnLoad(preparationLogicHolder);
 
         logic = preparationLogicHolder.GetCurrentPreparationLogic();
 
         logic.selectionFullnessChanged = null;
-        logic.selectionFullnessChanged += nextButtonFullnessChanged;
+        logic.selectionFullnessChanged += NextButtonFullnessChanged;
 
-        syncCards();
-        configureButtons();
+        SyncCards();
+        ConfigureButtons();
     }
 
-    void configureButtons()
+    static void EnableButton(Button button, string text, UnityAction onClick)
+    {
+        button.gameObject.SetActive(true);
+        if (!(text is null))
+            button.GetComponentInChildren<Text>().text = text;
+        button.onClick.RemoveAllListeners();
+        if (!(onClick is null))
+            button.onClick.AddListener(onClick);
+    }
+    static void DisableButton(Button button)
+    {
+        button.gameObject.SetActive(false);
+    }
+
+    void ConfigureButtons()
     {
         if (preparationLogicHolder.currentPlayer == PreparationLogicHolder.PlayerID.Player1)
         {
-            nextButton.GetComponentInChildren<Text>().text = "Player 2 - choose cards";
-            nextButton.onClick.AddListener(player2ChooseCardsButtonClicked);
-
-            backButton.gameObject.SetActive(false);
+            DisableButton(backButton);
+            EnableButton(nextButton, "Player 2 - choose cards", Player2ChooseCardsButtonClicked);
         }
         else
         {
-            nextButton.GetComponentInChildren<Text>().text = "Start game!";
-            nextButton.onClick.AddListener(startGameClicked);
-
-            backButton.gameObject.SetActive(true);
-            backButton.GetComponentInChildren<Text>().text = "Player 1 - choose cards";
-            backButton.onClick.AddListener(player1ChooseCardsButtonClicked);
+            EnableButton(backButton, "Player 1 - choose cards", Player1ChooseCardsButtonClicked);
+            EnableButton(nextButton, "Start game!", StartGameClicked);
         }
-        logic.evaluateSelectionFullness();
+        logic.EvaluateSelectionFullness();
     }
 
-    void nextButtonFullnessChanged(bool isFull)
+    void NextButtonFullnessChanged(bool isFull)
     {
         nextButton.interactable = isFull;
     }
 
-    public void player1ChooseCardsButtonClicked()
+    public void Player1ChooseCardsButtonClicked()
     {
         Debug.Log("player1ChooseCardsButtonClicked");
 
@@ -100,7 +109,7 @@ public class PreparationMain : MonoBehaviour
 
     }
 
-    public void player2ChooseCardsButtonClicked()
+    public void Player2ChooseCardsButtonClicked()
     {
         Debug.Log("player2ChooseCardsButtonClicked");
 
@@ -109,25 +118,25 @@ public class PreparationMain : MonoBehaviour
 
     }
 
-    void syncCards()
+    void SyncCards()
     {
         cardCollection.SyncWithCardList(logic.collection, cardsInScene);
         playerSelection.SyncWithCardList(logic.playerSelection, cardsInScene);
     }
 
-    public void moveCardToPlayerSelection(SimpleCard card)
+    public void MoveCardToPlayerSelection(SimpleCard card)
     {
-        logic.moveCardToPlayerSelection(card.cardGuid);
-        syncCards();
+        logic.MoveCardToPlayerSelection(card.cardGuid);
+        SyncCards();
     }
 
-    public void moveCardToCollection(SimpleCard card)
+    public void MoveCardToCollection(SimpleCard card)
     {
-        logic.moveCardToCollection(card.cardGuid);
-        syncCards();
+        logic.MoveCardToCollection(card.cardGuid);
+        SyncCards();
     }
 
-    public void startGameClicked()
+    public void StartGameClicked()
     {
         Debug.Log("startGameClicked");
         SceneManager.LoadScene("MainScene", LoadSceneMode.Single);

--- a/Assets/Scripts/GamePreparation/PreparationMain.cs
+++ b/Assets/Scripts/GamePreparation/PreparationMain.cs
@@ -4,21 +4,109 @@ using System.Collections.Generic;
 using BoardGame.Cards;
 using BoardGame.Preparation;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
 public class PreparationMain : MonoBehaviour
 {
 
+    public int playerSelectionSize = 5;
+
     public CardCollection cardCollection;
     public PlayerSelection playerSelection;
+    public Button backButton;
+    public Button nextButton;
 
     public Dictionary<Guid, GameObject> cardsInScene = new Dictionary<Guid, GameObject>();
 
+    public PreparationLogicHolder preparationLogicHolderPrefab;
+
     private PreparationLogic logic;
+    private PreparationLogicHolder preparationLogicHolder;
 
     // Start is called before the first frame update
+
+    PreparationLogicHolder GetOrCreateHolder()
+    {
+        GameObject obj = GameObject.Find("/PreparationLogicHolder");
+        PreparationLogicHolder holder;
+        if (obj is null)
+        {
+            Debug.Log("create new PreparationLogicHolder");
+
+            holder = Instantiate(preparationLogicHolderPrefab, null);
+            holder.name = "PreparationLogicHolder";
+            holder.currentPlayer = PreparationLogicHolder.PlayerID.Player1;
+            obj = holder.gameObject;
+        }
+        else
+        {
+            Debug.Log("reuse PreparationLogicHolder");
+            holder = obj.GetComponent<PreparationLogicHolder>();
+        }
+        if (holder.GetCurrentPreparationLogic() == null)
+            holder.SetCurrentPreparationLogic(new PreparationLogic(_selectionTargetSize: playerSelectionSize));
+        return holder;
+    }
+
     void Start()
     {
-        logic = new PreparationLogic();
+        Debug.Log("start preparation main");
+
+        preparationLogicHolder = GetOrCreateHolder();
+        DontDestroyOnLoad(preparationLogicHolder);
+
+        logic = preparationLogicHolder.GetCurrentPreparationLogic();
+
+        logic.selectionFullnessChanged = null;
+        logic.selectionFullnessChanged += nextButtonFullnessChanged;
+
         syncCards();
+        configureButtons();
+    }
+
+    void configureButtons()
+    {
+        if (preparationLogicHolder.currentPlayer == PreparationLogicHolder.PlayerID.Player1)
+        {
+            nextButton.GetComponentInChildren<Text>().text = "Player 2 - choose cards";
+            nextButton.onClick.AddListener(player2ChooseCardsButtonClicked);
+
+            backButton.gameObject.SetActive(false);
+        }
+        else
+        {
+            nextButton.GetComponentInChildren<Text>().text = "Start game!";
+            nextButton.onClick.AddListener(startGameClicked);
+
+            backButton.gameObject.SetActive(true);
+            backButton.GetComponentInChildren<Text>().text = "Player 1 - choose cards";
+            backButton.onClick.AddListener(player1ChooseCardsButtonClicked);
+        }
+        logic.evaluateSelectionFullness();
+    }
+
+    void nextButtonFullnessChanged(bool isFull)
+    {
+        nextButton.interactable = isFull;
+    }
+
+    public void player1ChooseCardsButtonClicked()
+    {
+        Debug.Log("player1ChooseCardsButtonClicked");
+
+        preparationLogicHolder.currentPlayer = PreparationLogicHolder.PlayerID.Player1;
+        SceneManager.LoadScene("CardSelection", LoadSceneMode.Single);
+
+    }
+
+    public void player2ChooseCardsButtonClicked()
+    {
+        Debug.Log("player2ChooseCardsButtonClicked");
+
+        preparationLogicHolder.currentPlayer = PreparationLogicHolder.PlayerID.Player2;
+        SceneManager.LoadScene("CardSelection", LoadSceneMode.Single);
+
     }
 
     void syncCards()
@@ -30,15 +118,19 @@ public class PreparationMain : MonoBehaviour
     public void moveCardToPlayerSelection(SimpleCard card)
     {
         logic.moveCardToPlayerSelection(card.cardGuid);
-        card.transform.parent = playerSelection.transform;
         syncCards();
     }
 
     public void moveCardToCollection(SimpleCard card)
     {
         logic.moveCardToCollection(card.cardGuid);
-        card.transform.parent = cardCollection.transform;
         syncCards();
+    }
+
+    public void startGameClicked()
+    {
+        Debug.Log("startGameClicked");
+        SceneManager.LoadScene("MainScene", LoadSceneMode.Single);
     }
 
 }

--- a/Assets/Scripts/GameProcess/SimpleCard.cs
+++ b/Assets/Scripts/GameProcess/SimpleCard.cs
@@ -23,7 +23,6 @@ public class SimpleCard : MonoBehaviour
 
     private void OnMouseDown()
     {
-        Debug.Log("Mouse down");
         clickAction(this);
     }
 }

--- a/Assets/StaticAssets/Prefabs/PreparationLogicHolder.prefab
+++ b/Assets/StaticAssets/Prefabs/PreparationLogicHolder.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1149720966711390274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1655630022207513760}
+  - component: {fileID: 1401163766356470153}
+  m_Layer: 0
+  m_Name: PreparationLogicHolder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1655630022207513760
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1149720966711390274}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 531.95294, y: 312.4269, z: -0.017489681}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1401163766356470153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1149720966711390274}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1985685e1b53949ee8f31e97e098fe34, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/StaticAssets/Prefabs/PreparationLogicHolder.prefab.meta
+++ b/Assets/StaticAssets/Prefabs/PreparationLogicHolder.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e9d1a57ab9eb4fd9aa165e1c715247d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StaticAssets/Scenes/CardSelection.unity
+++ b/Assets/StaticAssets/Scenes/CardSelection.unity
@@ -154,6 +154,138 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &403653676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 403653677}
+  - component: {fileID: 403653680}
+  - component: {fileID: 403653679}
+  - component: {fileID: 403653678}
+  m_Layer: 5
+  m_Name: Next
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &403653677
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403653676}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1480388138}
+  m_Father: {fileID: 935611585}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 137, y: 115.1}
+  m_SizeDelta: {x: 160, y: 72.61002}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &403653678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403653676}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 403653679}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: PreparationMain, Assembly-CSharp
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 0
+--- !u!114 &403653679
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403653676}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &403653680
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403653676}
+  m_CullTransparentMesh: 0
 --- !u!1 &576195388
 GameObject:
   m_ObjectHideFlags: 0
@@ -278,6 +410,72 @@ Transform:
   m_Father: {fileID: 331486368}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &660910824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 660910827}
+  - component: {fileID: 660910826}
+  - component: {fileID: 660910825}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &660910825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660910824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &660910826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660910824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &660910827
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660910824}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &806490041
 GameObject:
   m_ObjectHideFlags: 0
@@ -358,6 +556,305 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &935611584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 935611585}
+  - component: {fileID: 935611588}
+  - component: {fileID: 935611587}
+  - component: {fileID: 935611586}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &935611585
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935611584}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 986612352}
+  - {fileID: 403653677}
+  m_Father: {fileID: 1271361871}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &935611586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935611584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &935611587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935611584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &935611588
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935611584}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &945454215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 945454216}
+  - component: {fileID: 945454218}
+  - component: {fileID: 945454217}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &945454216
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945454215}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 986612352}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &945454217
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945454215}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Player 2 cards
+--- !u!222 &945454218
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945454215}
+  m_CullTransparentMesh: 0
+--- !u!1 &986612351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 986612352}
+  - component: {fileID: 986612355}
+  - component: {fileID: 986612354}
+  - component: {fileID: 986612353}
+  m_Layer: 5
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &986612352
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 986612351}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 945454216}
+  m_Father: {fileID: 935611585}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -49, y: 115.1}
+  m_SizeDelta: {x: 160, y: 72.61002}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &986612353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 986612351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 986612354}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &986612354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 986612351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &986612355
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 986612351}
+  m_CullTransparentMesh: 0
 --- !u!1 &996190200
 GameObject:
   m_ObjectHideFlags: 0
@@ -478,9 +975,10 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1271361870}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.7734063, y: -5.829586, z: -12.968694}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 935611585}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -660,6 +1158,85 @@ MonoBehaviour:
   preparationMain: {fileID: 2104015327}
   cardCreator: {fileID: 806490042}
   yOffset: 1.72
+--- !u!1 &1480388137
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1480388138}
+  - component: {fileID: 1480388140}
+  - component: {fileID: 1480388139}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1480388138
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480388137}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 403653677}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1480388139
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480388137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Player 2 cards
+--- !u!222 &1480388140
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480388137}
+  m_CullTransparentMesh: 0
 --- !u!1 &1620857363
 GameObject:
   m_ObjectHideFlags: 0
@@ -736,5 +1313,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46d023386b38e479b9e64ab9fe058ec9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerSelectionSize: 5
   cardCollection: {fileID: 1341426231}
   playerSelection: {fileID: 1397636334}
+  backButton: {fileID: 986612353}
+  nextButton: {fileID: 403653678}
+  preparationLogicHolderPrefab: {fileID: 1401163766356470153, guid: 1e9d1a57ab9eb4fd9aa165e1c715247d, type: 3}

--- a/GameLogic/Runtime/Cards/CardBuilder.cs
+++ b/GameLogic/Runtime/Cards/CardBuilder.cs
@@ -17,7 +17,7 @@ namespace BoardGame.Cards
             cardTemplates.Add(Card.Elf, new Card(Card.Elf, 4, 2));
         }
 
-        public static Card create(string name)
+        public static Card Create(string name)
         {
             return new Card(cardTemplates[name]);
         }

--- a/GameLogic/Runtime/GamePreparation.cs
+++ b/GameLogic/Runtime/GamePreparation.cs
@@ -7,13 +7,20 @@ namespace BoardGame.Preparation
 
     public class PreparationLogic
     {
+        int collectionRowsCount = 3;
+
         public List<Card> collection;
         public List<Card> playerSelection;
 
-        public PreparationLogic()
+        int selectionTargetSize;
+        public delegate void SelectionFullnessChanged(bool isFull);
+        public SelectionFullnessChanged selectionFullnessChanged;
+        bool selectionIsFull;
+
+        public PreparationLogic(int _selectionTargetSize)
         {
             collection = new List<Card>();
-            for (int i = 0; i < 2; i++)
+            for (int i = 0; i < collectionRowsCount; i++)
             {
                 collection.Add(CardBuilder.create(Card.Gnome));
                 collection.Add(CardBuilder.create(Card.Goblin));
@@ -23,8 +30,8 @@ namespace BoardGame.Preparation
 
             playerSelection = new List<Card>();
 
-            playerSelection.Add(CardBuilder.create(Card.Demon));  // just for test
-            playerSelection.Add(CardBuilder.create(Card.Elf));  // just for test
+            selectionTargetSize = _selectionTargetSize;
+            selectionIsFull = false;
         }
 
         private static void cardSwapLists(List<Card> from, List<Card> to, Guid cardGuid)
@@ -36,12 +43,25 @@ namespace BoardGame.Preparation
 
         public void moveCardToPlayerSelection(Guid cardGuid)
         {
+            if (selectionIsFull)
+                return;
             cardSwapLists(collection, playerSelection, cardGuid);
+            evaluateSelectionFullness();
+        }
+
+        public void evaluateSelectionFullness()
+        {
+            if (playerSelection.Count == selectionTargetSize)
+            {
+                selectionFullnessChanged(true);
+                selectionIsFull = true;
+            }
         }
 
         public void moveCardToCollection(Guid cardGuid)
         {
             cardSwapLists(playerSelection, collection, cardGuid);
+            selectionIsFull = false;
         }
 
     }

--- a/GameLogic/Runtime/GamePreparation.cs
+++ b/GameLogic/Runtime/GamePreparation.cs
@@ -22,10 +22,10 @@ namespace BoardGame.Preparation
             collection = new List<Card>();
             for (int i = 0; i < collectionRowsCount; i++)
             {
-                collection.Add(CardBuilder.create(Card.Gnome));
-                collection.Add(CardBuilder.create(Card.Goblin));
-                collection.Add(CardBuilder.create(Card.Demon));
-                collection.Add(CardBuilder.create(Card.Elf));
+                collection.Add(CardBuilder.Create(Card.Gnome));
+                collection.Add(CardBuilder.Create(Card.Goblin));
+                collection.Add(CardBuilder.Create(Card.Demon));
+                collection.Add(CardBuilder.Create(Card.Elf));
             }
 
             playerSelection = new List<Card>();
@@ -34,22 +34,22 @@ namespace BoardGame.Preparation
             selectionIsFull = false;
         }
 
-        private static void cardSwapLists(List<Card> from, List<Card> to, Guid cardGuid)
+        private static void CardSwapLists(List<Card> from, List<Card> to, Guid cardGuid)
         {
             int index = from.FindIndex(card => card.guid == cardGuid);
             to.Add(from[index]);
             from.RemoveAt(index);
         }
 
-        public void moveCardToPlayerSelection(Guid cardGuid)
+        public void MoveCardToPlayerSelection(Guid cardGuid)
         {
             if (selectionIsFull)
                 return;
-            cardSwapLists(collection, playerSelection, cardGuid);
-            evaluateSelectionFullness();
+            CardSwapLists(collection, playerSelection, cardGuid);
+            EvaluateSelectionFullness();
         }
 
-        public void evaluateSelectionFullness()
+        public void EvaluateSelectionFullness()
         {
             if (playerSelection.Count == selectionTargetSize)
             {
@@ -58,9 +58,9 @@ namespace BoardGame.Preparation
             }
         }
 
-        public void moveCardToCollection(Guid cardGuid)
+        public void MoveCardToCollection(Guid cardGuid)
         {
-            cardSwapLists(playerSelection, collection, cardGuid);
+            CardSwapLists(playerSelection, collection, cardGuid);
             selectionIsFull = false;
         }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SampleScene.unity
-    guid: 2cda990e2423bbf4892e6590ba056729
+    path: Assets/StaticAssets/Scenes/CardSelection.unity
+    guid: c2d0ad7e2335c4b50a9d5b65d2035f05
+  - enabled: 1
+    path: Assets/StaticAssets/Scenes/MainScene.unity
+    guid: 4bfae4890947b433e9544539886ccb78
   m_configObjects: {}


### PR DESCRIPTION
solves #20 

* added `Assets/Scripts/GamePreparation/PreparationLogicHolder.cs` script. It keeps `PreparationLogic` instances for player 1 and 2
* when CardSelection scene is loaded, `PreparationMain.cs` script detects if `PreparationLogicHolder` gameobject exists, and creates it when it is missing
* `PreparationLogicHolder` gameobject will not be destroyed when new scene is loaded, so it is possible to return back to and modify the selection. Also it will be used to pass the selection to the main scene
* `PreparationMain.cs` now configures back and next buttons. Their text and handlers are set depending on the current player
* `PreparationLogic` class has `selectionFullnessChanged` delegate method, which allows to enable/disable buttons, depending on whether player has fully chosen full chosen its card selection
