### PR TITLE
Implement drag and drop mechanic for a card

### DIFF
--- a/Assets/Scripts/Card/CardCreator.cs
+++ b/Assets/Scripts/Card/CardCreator.cs
@@ -20,18 +20,18 @@ public class CardCreator : MonoBehaviour
         facesPrefabsDict.Add(Card.Demon, facesPrefabs[3]);
     }
 
-    public GameObject createCard(Card card, Transform parent, Action<SimpleCard> _clickAction)
+    public GameObject createCard(Card card, Transform parent)
     {
         GameObject newCard = Instantiate(simpleCardPrefab, parent);
-        newCard.GetComponent<SimpleCard>().Setup(facesPrefabsDict[card.Name], _clickAction, card.guid);
+        newCard.GetComponent<SimpleCard>().Setup(facesPrefabsDict[card.Name], card.guid);
         return newCard;
     }
 
-    public GameObject getCard(Dictionary<Guid, GameObject> cardsInScene, Card card, Transform parent, Action<SimpleCard> _clickAction)
+    public GameObject getCard(Dictionary<Guid, GameObject> cardsInScene, Card card, Transform parent)
     {
         if (!cardsInScene.ContainsKey(card.guid))
-            cardsInScene[card.guid] = this.createCard(card, parent, _clickAction);
-        cardsInScene[card.guid].GetComponent<SimpleCard>().UpdateClickAction(_clickAction);
+            cardsInScene[card.guid] = this.createCard(card, parent);
+
         return cardsInScene[card.guid];
     }
 

--- a/Assets/Scripts/Card/SimpleCard.cs
+++ b/Assets/Scripts/Card/SimpleCard.cs
@@ -30,7 +30,7 @@ public class SimpleCard : MonoBehaviour
         if (collisionObject == null)
             this.PutCardToHand();
         else
-            collisionObject.RecieveObject(this);
+            collisionObject.ReceiveObject(this);
     }
 
     private void Update()
@@ -39,8 +39,8 @@ public class SimpleCard : MonoBehaviour
         {
             Debug.Log("Mouse button is clicked; Updating card position " + this.cardGuid);
 
-            Vector3 coursorePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-            this.transform.position = new Vector3(coursorePosition.x, coursorePosition.y, -5.0f);
+            Vector3 cursorPosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+            this.transform.position = new Vector3(cursorPosition.x, cursorPosition.y, -5.0f);
 
             Debug.Log("Mouse position " + Input.mousePosition + " Card position " + this.transform.position);
         }
@@ -59,7 +59,7 @@ public class SimpleCard : MonoBehaviour
 
         Debug.DrawRay(this.transform.position, transform.TransformDirection(Vector3.forward) * 20.0f, isHit ? Color.yellow : Color.red);
 
-        if (hit.collider == null)
+        if (!isHit)
             return null;
 
         IInteractable collisionObject = (IInteractable)hit.collider.GetComponent(hit.collider.name);

--- a/Assets/Scripts/Card/SimpleCard.cs
+++ b/Assets/Scripts/Card/SimpleCard.cs
@@ -2,45 +2,73 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-
 public class SimpleCard : MonoBehaviour
 {
     GameObject cardFace;
-    Action<SimpleCard> clickAction;
     public Guid cardGuid;
     public bool isSelected { get; private set; } = false;
+    public bool isPlacedOnBattlefield { get; private set; } = false;
 
-    public void Setup(GameObject _cardFaceTemplate, Action<SimpleCard> _clickAction, Guid _cardGuid)
+    public void Setup(GameObject _cardFaceTemplate, Guid _cardGuid)
     {
         cardFace = Instantiate(_cardFaceTemplate, this.transform);
-        clickAction = _clickAction;
         cardGuid = _cardGuid;
-    }
-
-    public void UpdateClickAction(Action<SimpleCard> _clickAction)
-    {
-        clickAction = _clickAction;
     }
 
     private void OnMouseDown()
     {
         this.isSelected = true;
-        clickAction(this);
     }
 
     private void OnMouseUp()
     {
+        Debug.Log("Mouse button is released; Do not move card " + this.cardGuid);
+
         this.isSelected = false;
-        // Move card back to the hand
+        IInteractable? collisionObject = this.GetColissionObject();
+
+        if (collisionObject == null)
+            this.PutCardToHand();
+        else
+            collisionObject.RecieveObject(this);
     }
 
     private void Update()
     {
         if (this.isSelected)
         {
-            Debug.Log("Mouse button is clicked; Updating card position");
+            Debug.Log("Mouse button is clicked; Updating card position " + this.cardGuid);
+
+            Vector3 coursorePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+            this.transform.position = new Vector3(coursorePosition.x, coursorePosition.y, -5.0f);
+
+            Debug.Log("Mouse position " + Input.mousePosition + " Card position " + this.transform.position);
         }
     }
 
+    private IInteractable? GetColissionObject()
+    {
+        RaycastHit hit;
+        bool isHit = Physics.Raycast(
+            this.transform.position,
+            transform.TransformDirection(Vector3.forward),
+            out hit,
+            Mathf.Infinity,
+            Physics.DefaultRaycastLayers
+        );
 
+        Debug.DrawRay(this.transform.position, transform.TransformDirection(Vector3.forward) * 20.0f, isHit ? Color.yellow : Color.red);
+
+        if (hit.collider == null)
+            return null;
+
+        IInteractable collisionObject = (IInteractable)hit.collider.GetComponent(hit.collider.name);
+
+        return collisionObject;
+    }
+
+    private void PutCardToHand()
+    {
+
+    }
 }

--- a/Assets/Scripts/Card/SimpleCard.cs
+++ b/Assets/Scripts/Card/SimpleCard.cs
@@ -8,10 +8,11 @@ public class SimpleCard : MonoBehaviour
     GameObject cardFace;
     Action<SimpleCard> clickAction;
     public Guid cardGuid;
+    public bool isSelected { get; private set; } = false;
 
     public void Setup(GameObject _cardFaceTemplate, Action<SimpleCard> _clickAction, Guid _cardGuid)
     {
-        cardFace = Instantiate(_cardFaceTemplate, transform);
+        cardFace = Instantiate(_cardFaceTemplate, this.transform);
         clickAction = _clickAction;
         cardGuid = _cardGuid;
     }
@@ -23,6 +24,23 @@ public class SimpleCard : MonoBehaviour
 
     private void OnMouseDown()
     {
+        this.isSelected = true;
         clickAction(this);
     }
+
+    private void OnMouseUp()
+    {
+        this.isSelected = false;
+        // Move card back to the hand
+    }
+
+    private void Update()
+    {
+        if (this.isSelected)
+        {
+            Debug.Log("Mouse button is clicked; Updating card position");
+        }
+    }
+
+
 }

--- a/Assets/Scripts/GamePreparation/CardCollection.cs
+++ b/Assets/Scripts/GamePreparation/CardCollection.cs
@@ -26,7 +26,7 @@ public class CardCollection : MonoBehaviour
                 currentRowSize = 0;
             }
 
-            GameObject cardObj = cardCreator.getCard(cardsInScene, cards[i], transform, preparationMain.MoveCardToPlayerSelection);
+            GameObject cardObj = cardCreator.getCard(cardsInScene, cards[i], transform);
 
             cardObj.transform.parent = transform;
             cardObj.transform.localPosition = xOffset * currentRowSize * Vector3.right;

--- a/Assets/Scripts/GamePreparation/PlayerSelection.cs
+++ b/Assets/Scripts/GamePreparation/PlayerSelection.cs
@@ -14,7 +14,7 @@ public class PlayerSelection : MonoBehaviour
     {
         for (int i = 0; i < cards.Count; i++)
         {
-            GameObject cardObj = cardCreator.getCard(cardsInScene, cards[i], transform, preparationMain.MoveCardToCollection);
+            GameObject cardObj = cardCreator.getCard(cardsInScene, cards[i], transform);
 
             cardObj.transform.parent = transform;
             cardObj.transform.localPosition = yOffset * i * Vector3.down;

--- a/Assets/Scripts/GameProcess/HandDrower.cs
+++ b/Assets/Scripts/GameProcess/HandDrower.cs
@@ -20,14 +20,15 @@ public class HandDrower : MonoBehaviour
     }
 
 
-    public void fillStartHand(GameObject cardParent, Vector3 cardPosition, List<Card> cards, Dictionary<Guid, GameObject> cardsInScene, Action<SimpleCard> clickAction)
+    public void fillStartHand(GameObject cardParent, Vector3 cardPosition, List<Card> cards, Dictionary<Guid, GameObject> cardsInScene)
     {
         int offset = 2;
 
         for (int card_counter = 0; card_counter < HandDrower.initialDrawSize; card_counter++)
         {
             if (!cardsInScene.ContainsKey(cards[card_counter].guid))
-                cardsInScene[cards[card_counter].guid] = cardCreator.createCard(cards[card_counter], cardParent.transform, clickAction);
+                cardsInScene[cards[card_counter].guid] = cardCreator.createCard(cards[card_counter], cardParent.transform);
+
             GameObject newCard = cardsInScene[cards[card_counter].guid];
             newCard.transform.position = cardPosition;
             cardPosition.x += offset;

--- a/Assets/Scripts/GameProcess/Main.cs
+++ b/Assets/Scripts/GameProcess/Main.cs
@@ -10,8 +10,6 @@ public class Main : MonoBehaviour
     public GameObject playerHand;
     public GameObject playerBattlefield;
 
-    private SimpleCard selectedCard;
-
     private PreparationLogicHolder preparationLogicHolder;
     // used for debugging
     public PreparationLogicHolder preparationLogicHolderPrefab;
@@ -31,7 +29,7 @@ public class Main : MonoBehaviour
         PreparationLogicHolder holder = Instantiate(preparationLogicHolderPrefab, null);
         holder.name = "PreparationLogicHolder";
 
-        PreparationLogic logic = PreparationLogic.LoadFromFile(System.IO.Path.Combine(gameObject.scene.path, "../playerSelection.xml"));
+        PreparationLogic logic = PreparationLogic.LoadFromFile(System.IO.Path.Combine(gameObject.scene.path, "../debug/playerPreparation.xml"));
         holder.player1Preparation = logic;
         return holder;
     }
@@ -53,12 +51,10 @@ public class Main : MonoBehaviour
         return holder;
     }
 
-
     void Start()
     {
         this.preparationLogicHolder = this.GetHolder();
         this.initialisePlayerHand();
-        this.initialisePlayerBattlefield();
     }
 
     private void initialisePlayerHand()
@@ -67,31 +63,6 @@ public class Main : MonoBehaviour
         HandDrower handDrower = this.playerHand.GetComponent<HandDrower>();
 
         Vector3 startCardPosition = HandDrower.calculateStartHandPosition(handPositionCoordinate: this.HandPosition);
-        handDrower.fillStartHand(cardParent: this.playerHand, cardPosition: startCardPosition,
-            cards: cards, cardsInScene: cardsInScene, clickAction: this.SelectCard);
-    }
-
-    private void initialisePlayerBattlefield()
-    {
-        /* Setup card movement action for the battlefield. */
-        PlayerBattlefield playArea = this.playerBattlefield.GetComponent<PlayerBattlefield>();
-        playArea.ClickAction = this.clickBattlefield;
-    }
-
-    public void SelectCard(SimpleCard card)
-    {
-        Debug.Log("Select card: " + card);
-        this.selectedCard = card;
-    }
-
-    public void clickBattlefield(PlayerBattlefield battlefield)
-    {
-        if (this.selectedCard != null)
-        {
-            this.selectedCard.transform.SetParent(battlefield.playerSlots[battlefield.NextCardPosition].transform);
-            this.selectedCard.transform.position = battlefield.playerSlots[battlefield.NextCardPosition].transform.position;
-
-            battlefield.NextCardPosition += 1;
-        }
+        handDrower.fillStartHand(cardParent: this.playerHand, cardPosition: startCardPosition, cards: cards, cardsInScene: cardsInScene);
     }
 }

--- a/Assets/Scripts/GameProcess/Main.cs
+++ b/Assets/Scripts/GameProcess/Main.cs
@@ -29,7 +29,7 @@ public class Main : MonoBehaviour
         PreparationLogicHolder holder = Instantiate(preparationLogicHolderPrefab, null);
         holder.name = "PreparationLogicHolder";
 
-        PreparationLogic logic = PreparationLogic.LoadFromFile(System.IO.Path.Combine(gameObject.scene.path, "../debug/playerPreparation.xml"));
+        PreparationLogic logic = PreparationLogic.LoadFromFile(System.IO.Path.Combine(gameObject.scene.path, "../playerSelection.xml"));
         holder.player1Preparation = logic;
         return holder;
     }

--- a/Assets/Scripts/GameProcess/PlayerBattlefield.cs
+++ b/Assets/Scripts/GameProcess/PlayerBattlefield.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class PlayerBattlefield : MonoBehaviour
+public class PlayerBattlefield : MonoBehaviour, IInteractable
 {
     public GameObject[] playerSlots;
 
@@ -14,7 +14,11 @@ public class PlayerBattlefield : MonoBehaviour
     private void OnMouseDown()
     {
         Debug.Log("Player battlefield is clicked");
-        this.ClickAction(this);
+    }
+
+    public void RecieveObject(MonoBehaviour obj)
+    {
+        Debug.Log("Object is recieved");
     }
 
 }

--- a/Assets/Scripts/GameProcess/PlayerBattlefield.cs
+++ b/Assets/Scripts/GameProcess/PlayerBattlefield.cs
@@ -16,9 +16,9 @@ public class PlayerBattlefield : MonoBehaviour, IInteractable
         Debug.Log("Player battlefield is clicked");
     }
 
-    public void RecieveObject(MonoBehaviour obj)
+    public void ReceiveObject(MonoBehaviour obj)
     {
-        Debug.Log("Object is recieved");
+        Debug.Log("Object is received");
     }
 
 }

--- a/Assets/Scripts/Interfaces.meta
+++ b/Assets/Scripts/Interfaces.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f944117f63b434bf9b87b7974a75dc7e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interfaces/Interactable.cs
+++ b/Assets/Scripts/Interfaces/Interactable.cs
@@ -1,0 +1,8 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using BoardGame.Cards;
+using UnityEngine;
+interface IInteractable{
+    void RecieveObject(MonoBehaviour obj);
+}

--- a/Assets/Scripts/Interfaces/Interactable.cs
+++ b/Assets/Scripts/Interfaces/Interactable.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using BoardGame.Cards;
 using UnityEngine;
-interface IInteractable{
+interface IInteractable
+{
     void RecieveObject(MonoBehaviour obj);
 }

--- a/Assets/Scripts/Interfaces/Interactable.cs
+++ b/Assets/Scripts/Interfaces/Interactable.cs
@@ -5,5 +5,5 @@ using BoardGame.Cards;
 using UnityEngine;
 interface IInteractable
 {
-    void RecieveObject(MonoBehaviour obj);
+    void ReceiveObject(MonoBehaviour obj);
 }

--- a/Assets/Scripts/Interfaces/Interactable.cs.meta
+++ b/Assets/Scripts/Interfaces/Interactable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7b67f2c217484d53970438a6b21537f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StaticAssets/Scenes/MainScene.unity
+++ b/Assets/StaticAssets/Scenes/MainScene.unity
@@ -209,7 +209,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 207773568}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.51, y: 0.42, z: 0}
+  m_LocalPosition: {x: -4.51, y: 0.42, z: -1}
   m_LocalScale: {x: 5, y: 1, z: 1}
   m_Children:
   - {fileID: 1134990696}
@@ -238,32 +238,19 @@ MonoBehaviour:
   - {fileID: 447329973}
   - {fileID: 659729618}
   - {fileID: 40543352}
---- !u!61 &207773571
-BoxCollider2D:
+--- !u!65 &207773571
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 207773568}
-  m_Enabled: 1
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 1, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
+  m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 3, y: 2}
-  m_EdgeRadius: 0
+  m_Size: {x: 5, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &331486367
 GameObject:
   m_ObjectHideFlags: 0
@@ -349,7 +336,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 478703415}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.51, y: 1.82, z: 0}
+  m_LocalPosition: {x: -4.51, y: 1.82, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2121581393}
@@ -385,7 +372,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 497500159}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.01, y: -3.39, z: 12}
+  m_LocalPosition: {x: -0.01, y: -3.39, z: -1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1620857364}
@@ -530,6 +517,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &627653001
@@ -745,7 +733,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 996190200}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.7734063, y: 5.829586, z: 2.9686937}
+  m_LocalPosition: {x: -0.7734063, y: 5.829586, z: -3.82}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 895238022}
@@ -929,7 +917,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1323019037}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0034063458, y: 0.029585838, z: 15}
+  m_LocalPosition: {x: -0.0034063458, y: 0.029585838, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1620857364}
@@ -1053,6 +1041,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 576195390}
     m_Modifications:
     - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1065,6 +1057,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -1075,14 +1071,6 @@ PrefabInstance:
     - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 262563990072792514, guid: 2d7c53dc20d8546e3b7ce1f66a900a4c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x


### PR DESCRIPTION
In that MR I'd like to introduce drag and drop mechanic for manipulating with cards. 

**Before:** Previously we had all callbacks are defined in the `Main.cs` and manipulating (set and call) via delegates. That lead to a lot of dependencies that are sent through the code and required to pass additional parameters during the initialisation + define it in the places (see `Main.cs` where it doesn't suit logically).

**Now:** Since `SimpleCard` card script is responsible for card visualisation (contains face prefab, card position on scene, etc.) we could say that it is the perfect place to define how card GUI representation should interact with mouse cursor. Since GUI is responsible for manipulating with an object, we also need to define how this object will be handed by others when mouse button will be up and card will be dropped to other object. For that purpose I've implemented the `IInteractable` interface that define method for receiving any type of object that is inherited from `MonoBehavior`. For now, only `PlayerBattlefield` implements this interface. The main point is that each object that could communicate with an another should implement this interface. In that case, caller side won't know any implementation details but only that object under selected one is able to handle it. 